### PR TITLE
fix(product): normalize skus structure and improve color/size parsing

### DIFF
--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -79,7 +79,32 @@ const parseColorFromName = (name: string): 'white' | 'black' | null => {
   return null
 }
 
+// Cor preferencialmente a partir de sku.variations (fallback para o título)
+const parseColorFromSku = (sku: any): 'white' | 'black' | null => {
+  const norm = (s: string) => (s || '').normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase()
+  const variations = Array.isArray(sku?.variations) ? sku.variations : []
+  const colorVar = variations.find((v: any) => {
+    const n = norm(v?.name)
+    return n.includes('cor') || n.includes('color')
+  })
+  const colorText = colorVar?.value ? norm(String(colorVar.value)) : norm(`${sku?.title || ''} ${sku?.name || ''}`)
+  if (colorText.includes('branco')) return 'white'
+  if (colorText.includes('preto')) return 'black'
+  return null
+}
+
+// Tamanho preferencialmente a partir de sku.variations (fallback regex)
 const parseSizeFromSku = (sku: any): number | null => {
+  const variations = Array.isArray(sku?.variations) ? sku.variations : []
+  const sizeVar = variations.find((v: any) => {
+    const n = (v?.name || '').toLowerCase()
+    return n.includes('tamanho') || n.includes('size')
+  })
+  if (sizeVar && sizeVar.value) {
+    const m = String(sizeVar.value).match(/\b(34|35|36|37|38|39|40)\b/)
+    const asNum = m ? Number(m[1]) : NaN
+    if (!Number.isNaN(asNum)) return asNum
+  }
   const text = `${(sku?.title || '')} ${(sku?.name || '')}`.toLowerCase()
   const match = text.match(/\b(34|35|36|37|38|39|40)\b/)
   return match ? Number(match[1]) : null
@@ -92,15 +117,16 @@ const fetchStockFromYampi = async () => {
     const map: Record<string, number> = {}
 
     data.forEach((product: any) => {
-      const colorId = parseColorFromName(product?.name)
-      if (!colorId) return
-
-      const skus = Array.isArray(product?.skus) ? product.skus : []
+      const skusRaw = product?.skus
+      const skus = Array.isArray(skusRaw) ? skusRaw : Array.isArray(skusRaw?.data) ? skusRaw.data : []
       skus.forEach((sku: any) => {
+        // Cor preferencialmente pelo SKU (variações), fallback ao nome do produto se não encontrar
+        const colorId = parseColorFromSku(sku) ?? parseColorFromName(product?.name)
+        if (!colorId) return
         const size = parseSizeFromSku(sku)
         if (!size) return
         const key = `${colorId}-${size}`
-        const stock = Number(sku?.total_in_stock || 0)
+        const stock = Number(sku?.total_in_stock ?? 0)
         map[key] = (map[key] || 0) + stock
       })
     })

--- a/src/components/YampiProducts.vue
+++ b/src/components/YampiProducts.vue
@@ -223,7 +223,11 @@ export default {
           page,
           skipCache: true
         });
-        this.products = response.data || [];
+        // Normaliza skus quando vierem como { data: [] }
+        this.products = (response.data || []).map(p => ({
+          ...p,
+          skus: Array.isArray(p.skus) ? p.skus : (Array.isArray(p.skus?.data) ? p.skus.data : [])
+        }));
         this.pagination = response.meta?.pagination || null;
       } catch (error) {
         this.error = `Erro ao carregar produtos: ${error.message}`;
@@ -238,7 +242,11 @@ export default {
       this.specificProductStock = null;
       try {
         const response = await yampiApi.getProductsInStock();
-        this.products = response.data || [];
+        // Também normaliza para exibição consistente
+        this.products = (response.data || []).map(p => ({
+          ...p,
+          skus: Array.isArray(p.skus) ? p.skus : (Array.isArray(p.skus?.data) ? p.skus.data : [])
+        }));
         this.pagination = response.meta?.pagination || null;
       } catch (error) {
         this.error = `Erro ao carregar produtos em estoque: ${error.message}`;

--- a/src/services/yampiApi.ts
+++ b/src/services/yampiApi.ts
@@ -13,7 +13,7 @@ export interface YampiSku {
 export interface YampiProduct {
   id: string | number;
   name: string;
-  skus?: YampiSku[];
+  skus?: any; // pode ser array ou objeto { data: [] }
   images?: any[];
   [key: string]: any;
 }
@@ -152,7 +152,8 @@ export class YampiAPI {
   async getProductsInStock(): Promise<GetProductsResponse> {
     const products = await this.getProducts({ include: 'skus' });
     const productsInStock = (products.data || []).filter(product => {
-      return product.skus && Array.isArray(product.skus) && product.skus.some(sku => (sku.total_in_stock || 0) > 0);
+      const skusArr = normalizeSkus(product.skus);
+      return skusArr.some(sku => (sku.total_in_stock || 0) > 0);
     });
 
     return {
@@ -165,11 +166,12 @@ export class YampiAPI {
   async checkProductStock(productId: string | number): Promise<ProductStockInfo> {
     const product = await this.getProduct(productId, 'skus');
 
-    if (!product.data?.skus || !Array.isArray(product.data.skus)) {
+    const skusArr = normalizeSkus(product.data?.skus);
+    if (!Array.isArray(skusArr) || skusArr.length === 0) {
       return { inStock: false, totalStock: 0, skus: [] };
     }
 
-    const skusWithStock = product.data.skus.map(sku => ({
+    const skusWithStock = skusArr.map(sku => ({
       id: sku.id,
       name: sku.title || sku.name,
       stock: sku.total_in_stock || 0,
@@ -187,3 +189,10 @@ export class YampiAPI {
 const yampiApi = new YampiAPI();
 
 export default yampiApi;
+
+// Helper para normalizar SKUs vindos da Yampi
+function normalizeSkus(skus: any): YampiSku[] {
+  if (Array.isArray(skus)) return skus as YampiSku[];
+  if (Array.isArray(skus?.data)) return skus.data as YampiSku[];
+  return [];
+}


### PR DESCRIPTION
Add helper function to normalize skus that may come as array or { data: [] } structure. Improve color detection by checking sku variations first before falling back to product name. Enhance size parsing to also check variations before regex matching.